### PR TITLE
Abbreviate parent surnames in homepage testimonials

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,19 +153,19 @@
         },
         {
           "@type": "Review",
-          "author": { "@type": "Person", "name": "Louise Cohen" },
+          "author": { "@type": "Person", "name": "Louise C." },
           "reviewBody": "Becca was a huge support with my son's delayed gross motor skills. The sessions were always fun and easy – she was great with our son and he always enjoyed the sessions, which felt more like play for him. The advice was always really helpful, and Becca gave us really clear, practical exercises to do between sessions. I'd highly recommend her.",
           "reviewRating": { "@type": "Rating", "ratingValue": "5", "bestRating": "5" }
         },
         {
           "@type": "Review",
-          "author": { "@type": "Person", "name": "Elli Menze" },
+          "author": { "@type": "Person", "name": "Elli M." },
           "reviewBody": "Becca assessed my 4 month old daughter and her advice has made a world of difference. From the moment we met her, she was warm, patient and incredibly knowledgeable. Thanks to her guidance, I now feel confident doing exercises like tummy time at home. I couldn't recommend her more highly!",
           "reviewRating": { "@type": "Rating", "ratingValue": "5", "bestRating": "5" }
         },
         {
           "@type": "Review",
-          "author": { "@type": "Person", "name": "Henry L" },
+          "author": { "@type": "Person", "name": "Henry L." },
           "reviewBody": "Rebecca was incredible throughout my son's knee rehabilitation. From the very first session, her professionalism and expertise put us both at ease. Her approach to goal-setting was exactly what he needed to stay on track, ensuring his successful and confident return to football.",
           "reviewRating": { "@type": "Rating", "ratingValue": "5", "bestRating": "5" }
         }
@@ -334,19 +334,19 @@
                         <div class="testimonials-slide" aria-hidden="true">
                             <blockquote class="testimonial-card">
                                 <p>"Becca was a huge support with my son's delayed gross motor skills. The sessions were always fun and easy – she was great with our son and he always enjoyed the sessions, which felt more like play for him. For us, the advice was always really helpful, and Becca gave us really clear, practical exercises to do between sessions. She was also really kind and reassuring, which I appreciated a lot in the situation. I'd highly recommend her."</p>
-                                <cite><strong>Louise Cohen</strong><span>Parent — East Dulwich</span></cite>
+                                <cite><strong>Louise C.</strong><span>Parent — East Dulwich</span></cite>
                             </blockquote>
                         </div>
                         <div class="testimonials-slide" aria-hidden="true">
                             <blockquote class="testimonial-card">
                                 <p>"Becca assessed my 4 month old daughter and her advice has made a world of difference. From the moment we met her, she was warm, patient and incredibly knowledgeable — she took the time to really understand our concerns and explained everything clearly without ever making me feel rushed or overwhelmed. Thanks to her guidance, I now feel confident doing exercises like tummy time at home and know exactly what milestones to look out for in the coming months. Becca has such a lovely way with both babies and parents, and I left our session feeling genuinely reassured about my daughter's development. I couldn't recommend her more highly!"</p>
-                                <cite><strong>Elli Menze</strong><span>Parent — East Dulwich</span></cite>
+                                <cite><strong>Elli M.</strong><span>Parent — East Dulwich</span></cite>
                             </blockquote>
                         </div>
                         <div class="testimonials-slide" aria-hidden="true">
                             <blockquote class="testimonial-card">
                                 <p>"Rebecca was incredible throughout my son's knee rehabilitation. From the very first session, her professionalism and expertise put us both at ease. Her approach to goal-setting was exactly what he needed to stay on track, ensuring his successful and confident return to football."</p>
-                                <cite><strong>Henry L</strong><span>Parent — Herne Hill</span></cite>
+                                <cite><strong>Henry L.</strong><span>Parent — Herne Hill</span></cite>
                             </blockquote>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- Replace full surnames with single-letter initials in homepage testimonials (parent privacy).
- Updates both the visible carousel attributions and the schema.org `Review` JSON-LD `author.name` fields, so the surnames are not exposed in indexed structured data either.
- Kath Thacker (Kingston Hospital — a professional clinical endorsement) is intentionally left intact.

Note: this PR also picks up 9 previously-unpushed commits on `main` (recent SEO/affiliates work), because local `main` was ahead of `origin/main` when the fix branch was cut. Merging will fast-forward those onto `origin/main` along with the testimonial change.

## Test plan
- [ ] Open the homepage; cycle the testimonials carousel and confirm: Kath Thacker (unchanged), Louise C., Elli M., Henry L.
- [ ] View page source and confirm the JSON-LD `author.name` values match the displayed attributions for the three parent reviews.
- [ ] Run the homepage through Google's Rich Results Test (or equivalent) to confirm the structured data still validates.