### PR TITLE
Ignore generated and per-developer files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,17 @@
 .github/copilot-instructions.md
 www.code-movewellkids.code-workspace
 MARKETING-PLAN.md
+
+.claude/
+
+*.heic
+
+node_modules/
+package.json
+package-lock.json
+
+gsc_coverage/
+movewellkids.co.uk-Coverage-*/
+movewellkids.co.uk-Coverage-*.zip
+
+*.log


### PR DESCRIPTION
## Summary
- Expand `.gitignore` so `git status` only surfaces intentional source changes.
- Adds patterns for: Claude Code's per-project config (`.claude/`), HEIC source images (`*.heic`), the npm toolchain pulled in for HEIC conversion (`node_modules/`, `package.json`, `package-lock.json`), Google Search Console exports (`gsc_coverage/`, `movewellkids.co.uk-Coverage-*`), and local server logs (`*.log`).

Note: this PR is opened against `main` and so also contains the 9 previously-unpushed commits on local `main` (recent SEO/affiliates work) plus the testimonial-privacy commit from #9 — same situation as #9. Merging #9 first will collapse this PR's diff to just the `.gitignore` change.

## Test plan
- [ ] Pull this branch locally and run `git status` — only intentional source changes should appear.
- [ ] Confirm none of the existing tracked files match the new ignore patterns (none should — `git ls-files | xargs -I{} git check-ignore {}` should return nothing).